### PR TITLE
Update simpleSlider.js

### DIFF
--- a/src/simpleSlider.js
+++ b/src/simpleSlider.js
@@ -70,7 +70,10 @@
 
                 // Make the slide indicators clickable
                 $("#"+ options.slideTrackerID +" ul li").click(function(){
-                    obj.nextSlide($(this).data('index'));
+                    if(!($(this).hasClass("active")))
+                	{
+                		obj.nextSlide($(this).data('index'));
+                	}
                 });
             }
 


### PR DESCRIPTION
Added an if statement to line 73 to make the slide indicator clickable only if it's not already active.
I believe this solves the issue where it hides the content when clicking the indicator for the already active slide.
I would imagine that it'd be better to modify the "nextSlide" function, but i couldn't figure out how to do so to keep it from hiding the slide's content. 
if(!($(this).hasClass("active")))
{
    obj.nextSlide($(this).data('index'));
}
